### PR TITLE
Do not track hotswaps

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -110,17 +110,9 @@ if (!argv.path) argv.path = process.cwd()
 
 var dl = torrent(source, argv)
 
-var hs;
-
-dl.on('hotswap', function() {
-  hs++
-})
-
 dl.on('ready', function() {
   console.log(dl.files.length.toString(), 'file(s) in torrent')
   console.log(dl.files.map(function(f){ return f.name.trim() }).join('\n'))
-
-  hs = 0
 
   var status = function() {
     var down = bytes(dl.swarm.downloaded)
@@ -130,7 +122,7 @@ dl.on('ready', function() {
 
     log(
       'Connected to '+dl.swarm.wires.reduce(notChoked, 0)+'/'+dl.swarm.wires.length+' peers\n'+
-      'Downloaded '+down+' ('+downSpeed+') with '+hs+' hotswaps\n'+
+      'Downloaded '+down+' ('+downSpeed+')\n'+
       'Uploaded '+up+ ' ('+upSpeed+')\n'
     )
   }


### PR DESCRIPTION
hotswap stats are only interesting when streaming which `torrent` doesn't do.
