### PR TITLE
only check for .torrent if the the path doesn't start with magnet:

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -113,7 +113,7 @@ if (source === 'create') {
   })
   dl.listen(0)
 } else {
-  if (source.indexOf('.torrent') > -1) source = fs.readFileSync(source)
+  if (source.indexOf('.torrent') > -1 && !/^magnet/.test(source)) source = fs.readFileSync(source)
 
   if (!argv.path) argv.path = process.cwd()
 


### PR DESCRIPTION
Some magnet links might have `.torrent` in their URL for other reasons than being a .torrent file on disk.

Before this patch:

```
$ torrent 'magnet:?xt=urn:btih:77e1a18941186c1e6441721df91183d2a339d103&dn=Citizenfour%5FEdward-Snowden%5FLaura-Poitras&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2F9.rarbg.com%3A2710%2Fannounce&tr=http%3A%2F%2Fannounce.torrentsmd.com%3A8080%2Fannounce.php'

fs.js:439
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENAMETOOLONG, name too long 'magnet:?xt=urn:btih:77e1a18941186c1e6441721df91183d2a339d103&dn=Citizenfour%5FEdward-Snowden%5FLaura-Poitras&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2F9.rarbg.com%3A2710%2Fannounce&tr=http%3A%2F%2Fannounce.torrentsmd.com%3A8080%2Fannounce.php'
    at Object.fs.openSync (fs.js:439:18)
    at Object.fs.readFileSync (fs.js:290:15)
    at Object.<anonymous> (/home/substack/projects/torrent/cli.js:116:52)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:929:3
```

After this patch:

```
$ torrent 'magnet:?xt=urn:btih:77e1a18941186c1e6441721df91183d2a339d103&dn=Citizenfour%5FEdward-Snowden%5FLaura-Poitras&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2F9.rarbg.com%3A2710%2Fannounce&tr=http%3A%2F%2Fannounce.torrentsmd.com%3A8080%2Fannounce.php'
2 files in torrent
Citizenfour_Edward-Snowden_Laura-Poitras.mp4
README.txt
Connected to 19/35 peers
Downloaded 18.69 MB (1.17 MB/s)
Uploaded 0 B (0 B/s)
Torrent Size 3.64 GB

Complete: 0.5138%
[                    ]
0%    25   50   75   100%

Estimated 1 hour, 9 minutes and 44 seconds remaining
```