### PR TITLE
Seed infile fix

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -108,8 +108,13 @@ if (source === 'create') {
   var infile = argv._.shift()
   var filename = infile
   if (!argv.path) argv.path = process.cwd()
-  if (source.indexOf('.torrent') > -1 && !/^magnet/.test(source)) source = fs.readFileSync(source)
-  var dl = torrent(infile, argv)
+  var body
+  if (!/^magnet:/.test(infile)) {
+    body = fs.readFileSync(infile)
+  }
+  else body = infile
+ 
+  var dl = torrent(body, argv)
   dl.on('ready', function() {
     var seeding = dl.torrent.pieces.every(function(piece, i) {
       return dl.bitfield.get(i)


### PR DESCRIPTION
The seed logic was passing `source` previously, which was just the literal string `"seed"`. This patch fixes `torrent seed` to use `infile` instead.

```
$ torrent seed auckland.torrent 
/home/substack/projects/torrent/node_modules/torrent-stream/index.js:69
	if (!link || !link.infoHash) throw new Error('You must pass a valid torrent o
	                                   ^
Error: You must pass a valid torrent or magnet link
    at torrentStream (/home/substack/projects/torrent/node_modules/torrent-stream/index.js:69:37)
    at module.exports (/home/substack/projects/torrent/index.js:6:16)
    at Object.<anonymous> (/home/substack/projects/torrent/cli.js:112:12)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```