### PR TITLE
accept torrent file from stdin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "create-torrent": "^3.7.1",
     "human-format": "^0.1.3",
     "minimist": "^0.1.0",
-    "parse-torrent": "^3.0.1",
+    "parse-torrent": "^4.0.0",
     "pretty-bytes": "^0.1.1",
     "pretty-seconds": "^0.1.3",
     "single-line-log": "^0.4.0",


### PR DESCRIPTION
This accepts a torrent-file from stdin downloading or seeding. Before, this was already possible with the info and ls command, this extends this support to cover all operations.

The dependency on `parse-torrent` has been bumped to a version that actually throws errors. It was previously wrapped in a try catch even though it returned `null` instead of throwing an error.