### PR TITLE
Bump torrent-stream version to address security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pretty-bytes": "^0.1.1",
     "pretty-seconds": "^0.1.3",
     "single-line-log": "^0.4.0",
-    "torrent-stream": "^0.19.2"
+    "torrent-stream": "^1.0.2"
   },
   "devDependencies": {
     "standard": "^5.0.0"


### PR DESCRIPTION
Running `npm i` on master yields:
```
bittorrent-dht@3.2.6: Critical security issue fixed in 5.1.3. 
All users should upgrade. (More info: https://github.com/feross/bittorrent-dht/issues/87)
```
This PR bumps `torrent-stream` version to address this security issue.